### PR TITLE
Update name/copyright strings in .sfd

### DIFF
--- a/white-bunnybat.sfd
+++ b/white-bunnybat.sfd
@@ -79,7 +79,7 @@ ShortTable: maxp 16
   0
   0
 EndShort
-LangName: 1033 "Copyright +AKkA 1999 by Matthew Welch. All Rights Reserved.+AAoA-Copyright +AKkA 2014-2022, Drizzly Bear LLC+AAoA-Copyright +AKkA 2023, ComCODE (https://comcode.org/)" "" "Regular" "white-bunnybat:Version 1.00" "" "Version 1.00"
+LangName: 1033 "Copyright +AKkA 1999 by Matthew Welch.+AAoA-Copyright +AKkA 2014-2022, Drizzly Bear LLC+AAoA-Copyright +AKkA 2023, ComCODE (https://comcode.org/)" "" "Regular" "white-bunnybat:Version 1.00" "" "Version 1.00"
 GaspTable: 1 65535 15 1
 Encoding: UnicodeBmp
 UnicodeInterp: none


### PR DESCRIPTION
### Problem

fixes #9

### Context

I decided to just delete the "trademark" string, which showed up in Element -> Font Info -> TTF Names in the fontforge UI, and appears in LangName in the .sfd :shrug: 

I also just used "white-bunnybat" everywhere and not "white-bunnybat Regular" or whatever, since we don't expect other "variants" of this font (I forget what they're called, faces?)