### PR TITLE
Pin CI actions to SHAs

### DIFF
--- a/.github/workflows/fontforge-validate.yml
+++ b/.github/workflows/fontforge-validate.yml
@@ -7,9 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        # v5 (at the time of commit)
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Run build in dev container
-        uses: devcontainers/ci@v0.3
+        # v0.3 (at the time of commit)
+        uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6
         with:
           # never push the devcontainer docker image to a registry ... for now
           push: never

--- a/.github/workflows/prettier-lint.yml
+++ b/.github/workflows/prettier-lint.yml
@@ -14,6 +14,7 @@ jobs:
     name: Prettier Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # v5 (at the time of commit)
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Run prettier
         run: npx prettier --check .


### PR DESCRIPTION
### Problem

[GitHub recommends pinning CI actions to specific SHAs](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions)

Part of #22

### Context

Only two actions needed currently:

- [actions/checkout@v5](https://github.com/actions/checkout/releases/tag/v5) -> https://github.com/actions/checkout/commit/93cb6efe18208431cddfb8368fd83d5badbf9bfd
- [devcontainers/ci@v0.3](https://github.com/devcontainers/ci/releases/tag/v0.3) -> https://github.com/devcontainers/ci/commit/8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6
