### PR TITLE
Skip fontforge validation when .sfd unchanged

### DIFF
--- a/.github/workflows/fontforge-validate.yml
+++ b/.github/workflows/fontforge-validate.yml
@@ -3,7 +3,25 @@ name: Fontforge validation
 on: [pull_request]
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      font: ${{ steps.changes.outputs.font }}
+    steps:
+      - # v3.0.2 (at the time of commit)
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+        id: changes
+        with:
+          filters: |
+            font:
+              - '*.sfd'
+
   build_and_test:
+    needs: check_changes
+    if: ${{ needs.check_changes.outputs.font == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Problem

The fontforge validation workflow spins up a devcontainer on every PR, even when no font files changed. This is slow and unnecessary for docs-only or config-only changes.

### Context

Uses `dorny/paths-filter` (SHA-pinned, v3.0.2) to skip the `build_and_test` job when no `*.sfd` files are in the diff. Matches the pattern used in `hackmud_trust_scripts`.