### PR TITLE
Update README.md typo from ./NOTICE.txt to NOTICE.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains the [Hackmud](https://hackmud.com/) game font, white-bunnybat.
 
-See [./NOTICE.txt](./NOTICE.txt) for licensing usage info.
+See [NOTICE.txt](./NOTICE.txt) for licensing usage info.
 
 ## How to contribute
 


### PR DESCRIPTION
### Problem

The line
See [./NOTICE.txt](https://github.com/comcode-org/white-bunnybat/blob/main/NOTICE.txt) for licensing usage info.

has the typo in `[./NOTICE.txt]` and should be `[NOTICE.txt]`