### PR TITLE
Add Block Elements from Symbols for Legacy Computing

### DIFF
--- a/white-bunnybat.sfd
+++ b/white-bunnybat.sfd
@@ -6674,7 +6674,7 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: upper_three_eights_block
+StartChar: upper_three_eighths_block
 Encoding: 129923 129923 197
 Width: 1200
 Flags: W
@@ -6689,7 +6689,7 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: upper_five_eights_block
+StartChar: upper_five_eighths_block
 Encoding: 129924 129924 198
 Width: 1200
 Flags: W
@@ -6719,7 +6719,7 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: upper_seven_eights_block
+StartChar: upper_seven_eighths_block
 Encoding: 129926 129926 200
 Width: 1200
 Flags: W
@@ -6749,7 +6749,7 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: right_three_eights_block
+StartChar: right_three_eighths_block
 Encoding: 129928 129928 202
 Width: 1200
 Flags: W
@@ -6764,7 +6764,7 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: right_five_eights_block
+StartChar: right_five_eighths_block
 Encoding: 129929 129929 203
 Width: 1200
 Flags: W
@@ -6794,7 +6794,7 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: right_seven_eights_block
+StartChar: right_seven_eighths_block
 Encoding: 129931 129931 205
 Width: 1200
 Flags: W

--- a/white-bunnybat.sfd
+++ b/white-bunnybat.sfd
@@ -6658,5 +6658,155 @@ SplineSet
  0 975 l 1,0,-1
 EndSplineSet
 EndChar
+
+StartChar: upper_one_quarter_block
+Encoding: 129922 129922 196
+Width: 1200
+Flags: W
+LayerCount: 2
+Fore
+SplineSet
+0 1639 m 1,0,-1
+ 1200 1639 l 1,1,-1
+ 1200 1128 l 1,2,-1
+ 0 1128 l 1,3,-1
+ 0 1639 l 1,0,-1
+EndSplineSet
+EndChar
+
+StartChar: upper_three_eights_block
+Encoding: 129923 129923 197
+Width: 1200
+Flags: W
+LayerCount: 2
+Fore
+SplineSet
+0 1639 m 1,0,-1
+ 1200 1639 l 1,1,-1
+ 1200 872 l 1,2,-1
+ 0 872 l 1,3,-1
+ 0 1639 l 1,0,-1
+EndSplineSet
+EndChar
+
+StartChar: upper_five_eights_block
+Encoding: 129924 129924 198
+Width: 1200
+Flags: W
+LayerCount: 2
+Fore
+SplineSet
+0 1639 m 1,0,-1
+ 1200 1639 l 1,1,-1
+ 1200 360 l 1,2,-1
+ 0 360 l 1,3,-1
+ 0 1639 l 1,0,-1
+EndSplineSet
+EndChar
+
+StartChar: upper_three_quarters_block
+Encoding: 129925 129925 199
+Width: 1200
+Flags: WO
+LayerCount: 2
+Fore
+SplineSet
+0 1633 m 1,0,-1
+ 1200 1633 l 1,1,-1
+ 1200 98 l 1,2,-1
+ 0 98 l 1,3,-1
+ 0 1633 l 1,0,-1
+EndSplineSet
+EndChar
+
+StartChar: upper_seven_eights_block
+Encoding: 129926 129926 200
+Width: 1200
+Flags: W
+LayerCount: 2
+Fore
+SplineSet
+0 1645 m 1,0,-1
+ 1200 1645 l 1,1,-1
+ 1200 -145 l 1,2,-1
+ 0 -145 l 1,3,-1
+ 0 1645 l 1,0,-1
+EndSplineSet
+EndChar
+
+StartChar: right_one_quarter_block
+Encoding: 129927 129927 201
+Width: 1200
+Flags: W
+LayerCount: 2
+Fore
+SplineSet
+900 1638 m 1,0,-1
+ 1200 1638 l 1,1,-1
+ 1200 -408 l 1,2,-1
+ 900 -408 l 1,3,-1
+ 900 1638 l 1,0,-1
+EndSplineSet
+EndChar
+
+StartChar: right_three_eights_block
+Encoding: 129928 129928 202
+Width: 1200
+Flags: W
+LayerCount: 2
+Fore
+SplineSet
+750 1638 m 1,0,-1
+ 1200 1638 l 1,1,-1
+ 1200 -408 l 1,2,-1
+ 750 -408 l 1,3,-1
+ 750 1638 l 1,0,-1
+EndSplineSet
+EndChar
+
+StartChar: right_five_eights_block
+Encoding: 129929 129929 203
+Width: 1200
+Flags: W
+LayerCount: 2
+Fore
+SplineSet
+450 1638 m 1,0,-1
+ 1200 1638 l 1,1,-1
+ 1200 -408 l 1,2,-1
+ 450 -408 l 1,3,-1
+ 450 1638 l 1,0,-1
+EndSplineSet
+EndChar
+
+StartChar: right_three_quarters_block
+Encoding: 129930 129930 204
+Width: 1200
+Flags: W
+LayerCount: 2
+Fore
+SplineSet
+300 1638 m 5,0,-1
+ 1200 1638 l 5,1,-1
+ 1200 -408 l 5,2,-1
+ 300 -408 l 5,3,-1
+ 300 1638 l 5,0,-1
+EndSplineSet
+EndChar
+
+StartChar: right_seven_eights_block
+Encoding: 129931 129931 205
+Width: 1200
+Flags: W
+LayerCount: 2
+Fore
+SplineSet
+1200 1638 m 1,0,-1
+ 1200 -408 l 1,1,-1
+ 150 -408 l 1,2,-1
+ 150 1638 l 1,3,-1
+ 1200 1638 l 1,0,-1
+EndSplineSet
+EndChar
 EndChars
 EndSplineFont

--- a/white-bunnybat.sfd
+++ b/white-bunnybat.sfd
@@ -81,7 +81,7 @@ ShortTable: maxp 16
 EndShort
 LangName: 1033 "Copyright +AKkA 1999 by Matthew Welch.+AAoA-Copyright +AKkA 2014-2022, Drizzly Bear LLC+AAoA-Copyright +AKkA 2023, ComCODE (https://comcode.org/)" "" "Regular" "white-bunnybat:Version 1.00" "" "Version 1.00"
 GaspTable: 1 65535 15 1
-Encoding: UnicodeBmp
+Encoding: Custom
 UnicodeInterp: none
 NameList: AGL For New Fonts
 DisplaySize: -48
@@ -98,7 +98,7 @@ Grid
  4096 1365 l 1024
   Named: "top_max"
 EndSplineSet
-BeginChars: 65539 196
+BeginChars: 1114112 206
 
 StartChar: .notdef
 Encoding: 65536 -1 0


### PR DESCRIPTION
### Problem

@CakeEaterGames was trying to render some `CON_A5VAH` graphs and ran into the problem that there are no "right-side" partial block characters in the font ([ref discord:#0000](https://discord.com/channels/229545531104296960/229545531104296960/1500788710973771798)); however these *do* exist in Unicode.

### Context

As the characters in question are outside the Basic Multilingual Plane, the encoding space was expanded to cover all of Unicode. This isn't _strictly_ required, but makes it easier to add more astral characters in future.

Modification date and window information was intentionally excluded from the changes to the `.sfd` file.